### PR TITLE
Remove redundant condition

### DIFF
--- a/web/controllers/AuthController.php
+++ b/web/controllers/AuthController.php
@@ -301,7 +301,7 @@ class AuthController extends \web\ext\Controller
         } catch (\Exception $e) {
             $success = false;
         }
-        if (isset($emailConfirmation) && $emailConfirmation !== null) {
+        if (isset($emailConfirmation)) {
             $user = User::model()->findByPk(new \MongoId($emailConfirmation->userId));
             $user->isEmailConfirmed = true;
             $user->save();


### PR DESCRIPTION
There's no need to check if `$emailConfirmation` isn't null since `isset($emailConfirmation)` will return `true` when value is not null.